### PR TITLE
Allow CNAME handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -146,8 +146,13 @@ const task = {
          .pipe(gulpIf(settings.compress, prettify({ indent_size: 3 })))
          .pipe(gulp.dest('build'));
       },
+    buildCNAME: () => {
+      return gulp.src('source/CNAME', { allowEmpty: true })
+         .pipe(gulp.dest('build'));
+      },
    build: () => {
       return mergeStream(
+         task.buildCNAME(),
          task.buildFonts(),
          task.buildImages(),
          task.buildJs(),
@@ -176,7 +181,7 @@ const task = {
       },
    publishToDocs: () => {
       // fs.mkdirSync('docs');
-      fs.writeFileSync('docs/CNAME', 'node-slate.js.org\n');
+      // fs.writeFileSync('docs/CNAME', 'node-slate.js.org\n');
       return gulp.src('build/**/*')
          .pipe(gulp.dest('docs'));
       }


### PR DESCRIPTION
So I see that the CNAME is 1) hardcoded to node-slate.js.org and also does not get pushed to .build for deploy. This PR removes the hard code creation and, on deploy, checks to see if there is a CNAME in `source` and will push that to `build` for deploy to GH. 