### PR TITLE
Add Base URL suport

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -21,6 +21,7 @@ under the License.
    <head>
       <meta charset=utf-8>
       <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+      <base href="<%- current_page.data.base_url || '/' %>" target="_blank">
       <title><%= current_page.data.title || "API Documentation" %></title>
       <link rel=icon href=images/bookmark.png>
       <%- stylesheet_link_tag('screen', 'screen') %>

--- a/source/index.yml
+++ b/source/index.yml
@@ -17,3 +17,5 @@ includes:
 search: true
 
 highlight_theme: monokai
+
+base_url: /


### PR DESCRIPTION
In some cases external resources are breaking when the documentation is not in root